### PR TITLE
Adding wheel dependency (version 0.33.4)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ urllib3==1.24.1
 virtualenv==16.6.0
 wcwidth==0.1.7
 webencodings==0.5.1
+wheel==0.33.4


### PR DESCRIPTION
Useful when packaging before sending to PyPI.